### PR TITLE
Shuffle answer possibilities

### DIFF
--- a/question_panel/question_panel.gd
+++ b/question_panel/question_panel.gd
@@ -16,7 +16,10 @@ func display_question(difficulty):
 	question = question_handler.get_random_question(difficulty)
 	question_label.set_text(question.question)
 
-	for answer_possibility in question.answer_possibilities:
+	var answer_possibilities = question.answer_possibilities.duplicate()
+	answer_possibilities.shuffle()
+
+	for answer_possibility in answer_possibilities:
 		var answer_button = create_answer_button(answer_possibility, _on_answer_selected)
 		
 		answer_container.add_child(answer_button)


### PR DESCRIPTION
The position of the correct answer in the JSON array is always the first element. As it is now, you always answer correctly by clicking on the upper left answer.

tbh, I do not know why the correct answer possibility is separately specified in the JSON file if it is always the first option, but yet here we are.